### PR TITLE
expose copy argument from mflow.connect (>=0.2.0)

### DIFF
--- a/bsread/bsread.py
+++ b/bsread/bsread.py
@@ -17,10 +17,10 @@ BIND = "bind"
 class source:
 
     def __init__(self, host=None, port=9999, config_port=None, conn_type=CONNECT, mode=None, queue_size=100,
-                 channels=None, config_address=None, all_channels=False, receive_timeout=None,
+                 copy=True, channels=None, config_address=None, all_channels=False, receive_timeout=None,
                  dispatcher_url='https://dispatcher-api.psi.ch/sf', dispatcher_verify_request=True):
         self.source = Source(host=host, port=port, config_port=config_port, conn_type=conn_type, mode=mode,
-                             queue_size=queue_size, channels=channels, config_address=config_address,
+                             queue_size=queue_size, copy=copy, channels=channels, config_address=config_address,
                              all_channels=all_channels, receive_timeout=receive_timeout, dispatcher_url=dispatcher_url,
                              dispatcher_verify_request=dispatcher_verify_request)
 
@@ -35,7 +35,7 @@ class source:
 class Source:
 
     def __init__(self, host=None, port=9999, config_port=None, conn_type=CONNECT, mode=None, queue_size=100,
-                 channels=None, config_address=None, all_channels=False, receive_timeout=None,
+                 copy=True, channels=None, config_address=None, all_channels=False, receive_timeout=None,
                  dispatcher_url='https://dispatcher-api.psi.ch/sf', dispatcher_verify_request=True):
         """
 
@@ -73,6 +73,7 @@ class Source:
         self.config_port = config_port
         self.conn_type = conn_type
         self.queue_size = queue_size
+        self.copy = copy
         self.receive_timeout = receive_timeout
 
         self.dispatcher_url = dispatcher_url
@@ -141,7 +142,7 @@ class Source:
 
     def connect(self):
         self.stream = mflow.connect(self.address, conn_type=self.conn_type, queue_size=self.queue_size, mode=self.mode,
-                                    receive_timeout=self.receive_timeout)
+                                    copy=self.copy, receive_timeout=self.receive_timeout)
         return self  # Return self to be backward compatible
 
     def disconnect(self):

--- a/bsread/sender.py
+++ b/bsread/sender.py
@@ -25,10 +25,10 @@ BIND = "bind"
 # Support of "with" statement
 class sender:
     def __init__(self, queue_size=10, port=9999, conn_type=BIND, mode=PUSH, block=True, start_pulse_id=0,
-                 data_header_compression=None, data_compression=None, send_timeout=None):
+                 data_header_compression=None, data_compression=None, send_timeout=None, copy=True):
         self.sender = Sender(queue_size=queue_size, port=port, conn_type=conn_type, mode=mode, block=block,
                              start_pulse_id=start_pulse_id, data_header_compression=data_header_compression,
-                             data_compression=data_compression, send_timeout=send_timeout)
+                             data_compression=data_compression, send_timeout=send_timeout, copy=copy)
 
     def __enter__(self):
         self.sender.open()
@@ -40,8 +40,10 @@ class sender:
 
 class Sender:
     def __init__(self, queue_size=10, port=9999, address="tcp://*", conn_type=BIND, mode=PUSH, block=True,
-                 start_pulse_id=0, data_header_compression=None, send_timeout=None, data_compression=None):
+                 start_pulse_id=0, data_header_compression=None, send_timeout=None, data_compression=None,
+                 copy=True):
 
+        self.copy = copy
         self.block = block
         self.queue_size = queue_size
         self.port = port
@@ -106,7 +108,7 @@ class Sender:
     def open(self, no_client_action=None, no_client_timeout=None):
         self.stream = mflow.connect('%s:%d' % (self.address, self.port), queue_size=self.queue_size,
                                     conn_type=self.conn_type, mode=self.mode, no_client_action=no_client_action,
-                                    no_client_timeout=no_client_timeout, send_timeout=self.send_timeout)
+                                    no_client_timeout=no_client_timeout, copy=self.copy, send_timeout=self.send_timeout)
 
         # Main header
         self.main_header = dict()

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
         - pip
     run:
         - python
-        - mflow >=0.0.23
+        - mflow >=0.2.0
         - bitshuffle
         - numpy
         - pyzmq


### PR DESCRIPTION
The _copy_ argument can only be passed to mflow inside the constructor. This PR adds _copy_ to the keyword arguments.