### PR TITLE
Bugfixes

### DIFF
--- a/bsread/bs.py
+++ b/bsread/bs.py
@@ -38,8 +38,10 @@ def main():
     # except:
     try:
         command_script = importlib.import_module('bsread.'+command)
-    except ImportError:
-        print(command + ' - Command not found')
+    except ImportError as e:
+        # this catches not only the ImportError from importing the command here
+        # but also ImportErrors inside the command
+        print(command + ' - Command not found (' + str(e) + ')')
         usage()
         exit(-1)
 

--- a/bsread/h5.py
+++ b/bsread/h5.py
@@ -223,7 +223,7 @@ def main():
     except KeyboardInterrupt:
         # KeyboardInterrupt is thrown if the receiving is terminated via ctrl+c
         # As we don't want to see a stacktrace then catch this exception
-        pass
+        print() # print ^C on its own line 
     finally:
         if use_dispatching:
             print('Closing stream')

--- a/bsread/receive.py
+++ b/bsread/receive.py
@@ -108,7 +108,7 @@ def receive_(channels, source, mode, clear, queue_size, base_url, backend):
     except KeyboardInterrupt:
         # KeyboardInterrupt is thrown if the receiving is terminated via ctrl+c
         # As we don't want to see a stacktrace then catch this exception
-        pass
+        print() # print ^C on its own line
     finally:
         if use_dispatching:
             print('Closing stream')

--- a/bsread/stats.py
+++ b/bsread/stats.py
@@ -184,7 +184,7 @@ def stats(channels, source, mode, clear, queue_size, base_url, backend, logfile,
     except KeyboardInterrupt:
         # KeyboardInterrupt is thrown if the receiving is terminated via ctrl+c
         # As we don't want to see a stacktrace then catch this exception
-        pass
+        print() # print ^C on its own line
     finally:
         if use_dispatching:
             print('Closing stream')

--- a/bsread/utils.py
+++ b/bsread/utils.py
@@ -1,5 +1,4 @@
 import re
-import click
 
 
 def get_base_url(base_url=None, backend=None):

--- a/bsread/utils.py
+++ b/bsread/utils.py
@@ -18,11 +18,11 @@ def check_and_update_uri(uri, default_port=9999, exception=ValueError):
 
     if not re.match('^tcp://', uri):
         # print('Protocol not defined for address - Using tcp://')
-        address = 'tcp://' + uri
-    if not re.match('.*:[0-9]+$', address):
+        uri = 'tcp://' + uri
+    if not re.match('.*:[0-9]+$', uri):
         # print('Port not defined for address - Using 9999')
-        address += f':{default_port}'
-    if not re.match(r"^tcp://[a-zA-Z.\-0-9]+:[0-9]+$", address):
+        uri += f':{default_port}'
+    if not re.match(r"^tcp://[a-zA-Z.\-0-9]+:[0-9]+$", uri):
         raise exception(f"{uri} - Invalid URI")
 
-    return address
+    return uri


### PR DESCRIPTION
Fixed a few bugs/problems:
- In `check_and_update_uri()`, the body of the first `if` can be skipped and then `address` is not defined. Hence, this would fail for a specified source which already starts with "tcp://".
- Catching ImportError would not only silence an error during the local import, but also inside the file defining the command. Better to print the error message as part of the error that's already printed anyway.
- It's nicer to print:
```
^C
Closing stream
```
than:
```
^CClosing stream
```
