### PR TITLE
Bugfix: serialization of empty lists and booleans

### DIFF
--- a/bsread/data/helpers.py
+++ b/bsread/data/helpers.py
@@ -55,7 +55,7 @@ def get_channel_specs(value, extended=False):
         # Get to the bottom of the list.
         base_value = value
         while isinstance(base_value, list):
-            base_value = base_value[0]
+            base_value = base_value[0] if base_value else None
 
         # Lists have a special serializer.
         def serializer(list_value, suggested_type):

--- a/bsread/data/serialization.py
+++ b/bsread/data/serialization.py
@@ -96,7 +96,7 @@ channel_type_deserializer_mapping = {
     'float32': ('f4', deserialize_number),
     'float64': ('f8', deserialize_number),
     'string': ('u1', deserialize_string),
-    'bool': ('u1', deserialize_number)
+    'bool': ('?', deserialize_number)
 }
 
 
@@ -118,5 +118,5 @@ channel_type_scalar_serializer_mapping = {
     numpy.uint64: ('u8', 'uint64', serialize_numpy, [1]),
     numpy.float32: ('f4', 'float32', serialize_numpy, [1]),
     numpy.float64: ('f8', 'float64', serialize_numpy, [1]),
-    bool: ('u1', 'bool', serialize_python_number, [1])
+    bool: ('?', 'bool', serialize_python_number, [1])
 }

--- a/bsread/data/serialization.py
+++ b/bsread/data/serialization.py
@@ -118,5 +118,6 @@ channel_type_scalar_serializer_mapping = {
     numpy.uint64: ('u8', 'uint64', serialize_numpy, [1]),
     numpy.float32: ('f4', 'float32', serialize_numpy, [1]),
     numpy.float64: ('f8', 'float64', serialize_numpy, [1]),
-    bool: ('?', 'bool', serialize_python_number, [1])
+    bool: ('?', 'bool', serialize_python_number, [1]),
+    numpy.bool_: ('?', 'bool', serialize_numpy, [1])
 }

--- a/bsread/data/serialization.py
+++ b/bsread/data/serialization.py
@@ -118,4 +118,5 @@ channel_type_scalar_serializer_mapping = {
     numpy.uint64: ('u8', 'uint64', serialize_numpy, [1]),
     numpy.float32: ('f4', 'float32', serialize_numpy, [1]),
     numpy.float64: ('f8', 'float64', serialize_numpy, [1]),
+    bool: ('u1', 'bool', serialize_python_number, [1])
 }


### PR DESCRIPTION
Two bug fixes for the serialization:

- Empty lists are crashing the sender since there's no type of the contents. This PR uses `None` in that case.

- bools are not treated entirely correctly.
  - they are missing in the serialization (but can be deserialized).
  - `np.bool_` is not covered either, so boolean numpy arrays don't work.
  - they are treated as `uint8`, so you get 0/1 instead of False/True. This is solved by using the correct* type string `'?'` instead of `'u1'`.

Open question: are these changes compatible with the other bsread libs (C, rust, java?)

---

*https://numpy.org/doc/stable/reference/arrays.dtypes.html#specifying-and-constructing-data-types