### PR TITLE
Nicer Tables for bs receive

### DIFF
--- a/bsread/receive.py
+++ b/bsread/receive.py
@@ -5,8 +5,10 @@ from bsread import dispatcher, utils
 import zmq
 import numpy
 
+from . import tables
 
-def receive(source=None, clear=False, queue_size=100, mode=zmq.PULL, channel_filter=None):
+
+def receive(source=None, clear=False, table="auto", queue_size=100, mode=zmq.PULL, channel_filter=None):
     numpy.set_printoptions(threshold=5)
     numpy.set_printoptions(linewidth=100)
 
@@ -15,61 +17,14 @@ def receive(source=None, clear=False, queue_size=100, mode=zmq.PULL, channel_fil
     receiver = mflow.connect(source, conn_type="connect", queue_size=queue_size, mode=mode)
     handler = Handler()
 
-    while True:
-        message = receiver.receive(handler=handler.receive)
-        message = message.data  # As the rest of the code is only interested in the message data, not statistics
-
-        # if message_data['header']['pulse_id'] % 10 == 0:
-        #     sys.stderr.write("\x1b[2J\x1b[H")
-
-        if clear:
-            print((chr(27) + "[2J"))
-
-        separator = '\t'
-        # separator = ', '
-
-        if message.format_changed or clear:
-            # Have pulse_id, ... in first column
-            keys = "pulse_id" + separator + "global_timestamp" + separator + "global_timestamp_offset"
-
-            for key in message.data.keys():
-
-                if channel_filter and key not in channel_filter:
-                    # continue with next element as this one is not in the filter list
-                    continue
-
-                if keys:
-                    keys = keys + separator + key
-                else:
-                    keys = key
-
-            print(keys)
-
-        # pprint.pprint(message.data.values())
-        # Have pulse_id in first column
-        values = str(message.pulse_id) + separator + str(message.global_timestamp) + separator + str(
-            message.global_timestamp_offset)
-
-        for key in message.data.keys():
-
-            if channel_filter and key not in channel_filter:
-                # continue with next element as this one is not in the filter list
-                continue
-
-            value = message.data[key]
-            if values:
-                values = values + separator + str(value.value)
-            else:
-                values = str(value.value)
-
-        # for value in message.data.values():
-        #
-        #     if values:
-        #         values = values + separator + str(value.value)
-        #     else:
-        #         values = str(value.value)
-
-        print(values)
+    receive = lambda: receiver.receive(handler=handler.receive).data
+    Table = tables.available[table]
+    table = Table(receive)
+    try:
+        table.start()
+    finally:
+        table.stop()
+        receiver.disconnect()
 
 
 @click.command()
@@ -79,10 +34,11 @@ def receive(source=None, clear=False, queue_size=100, mode=zmq.PULL, channel_fil
               type=click.Choice(["pull", "sub"], case_sensitive=False),
               help="Communication mode - either pull or sub (default depends on the use of -s option)")
 @click.option("--clear", default=False, is_flag=True, help="Monitor mode / clear the screen on every message")
+@click.option("-t", "--table", type=click.Choice(tables.available), default="auto", help="Table mode")
 @click.option("-q", "--queue", "queue_size", default=100, type=int, help="Queue size of incoming queue")
 @click.option("--base_url", default=None, help="URL of dispatcher")
 @click.option("--backend", default=None, help="Backend to query")
-def receive_(channels, source, mode, clear, queue_size, base_url, backend):
+def receive_(channels, source, mode, clear, table, queue_size, base_url, backend):
 
     base_url = utils.get_base_url(base_url, backend)
 
@@ -103,7 +59,7 @@ def receive_(channels, source, mode, clear, queue_size, base_url, backend):
         source = dispatcher.request_stream(channels, base_url=base_url)
 
     try:
-        receive(source=source, clear=clear, queue_size=queue_size, mode=mode, channel_filter=channel_filter)
+        receive(source=source, clear=clear, table=table, queue_size=queue_size, mode=mode, channel_filter=channel_filter)
 
     except KeyboardInterrupt:
         # KeyboardInterrupt is thrown if the receiving is terminated via ctrl+c

--- a/bsread/receive.py
+++ b/bsread/receive.py
@@ -19,7 +19,7 @@ def receive(source=None, clear=False, table="auto", queue_size=100, mode=zmq.PUL
 
     receive = lambda: receiver.receive(handler=handler.receive).data
     Table = tables.available[table]
-    table = Table(receive)
+    table = Table(receive, channel_filter)
     try:
         table.start()
     finally:

--- a/bsread/receive.py
+++ b/bsread/receive.py
@@ -19,7 +19,7 @@ def receive(source=None, clear=False, table="auto", queue_size=100, mode=zmq.PUL
 
     receive = lambda: receiver.receive(handler=handler.receive).data
     Table = tables.available[table]
-    table = Table(receive, channel_filter)
+    table = Table(receive, channel_filter, clear)
     try:
         table.start()
     finally:

--- a/bsread/tables/__init__.py
+++ b/bsread/tables/__init__.py
@@ -1,0 +1,30 @@
+
+from .classic import ClassicTable
+from .plain import PlainTable
+
+try:
+    from .rich import RichTable
+except ImportError:
+    pass
+
+try:
+    from .textual import TextualTable
+except ImportError:
+    pass
+
+
+def available():
+    suffix = "Table"
+    res = {k[:-len(suffix)].lower(): v for k, v in globals().items() if k.endswith(suffix)}
+
+    auto_order = ("textual", "rich", "plain", "classic")
+    for n in auto_order:
+        if n in res:
+            res["auto"] = res[n]
+            break
+
+    return res
+
+available = available()
+
+

--- a/bsread/tables/bases.py
+++ b/bsread/tables/bases.py
@@ -1,0 +1,46 @@
+from abc import ABC, abstractmethod
+
+from .data import TableData
+
+
+class BaseDataTable(ABC):
+
+    def __init__(self, receive_func, max_rows):
+        self.data = TableData(receive_func, max_rows)
+
+    def start(self):
+        try:
+            self.data.start()
+            self.run()
+        except KeyboardInterrupt:
+            self.stop()
+
+    def stop(self):
+        self.data.stop()
+
+    @abstractmethod
+    def run(self):
+        raise NotImplementedError
+
+
+
+class BaseTable(ABC):
+
+    def __init__(self, receive_func):
+        self.receive_func = receive_func
+
+    def start(self):
+        try:
+            self.run()
+        except KeyboardInterrupt:
+            pass
+
+    def stop(self):
+        pass
+
+    @abstractmethod
+    def run(self):
+        raise NotImplementedError
+
+
+

--- a/bsread/tables/bases.py
+++ b/bsread/tables/bases.py
@@ -5,8 +5,8 @@ from .data import TableData
 
 class BaseDataTable(ABC):
 
-    def __init__(self, receive_func, max_rows):
-        self.data = TableData(receive_func, max_rows)
+    def __init__(self, receive_func, max_rows, channel_filter):
+        self.data = TableData(receive_func, max_rows, channel_filter)
 
     def start(self):
         try:
@@ -26,8 +26,9 @@ class BaseDataTable(ABC):
 
 class BaseTable(ABC):
 
-    def __init__(self, receive_func):
+    def __init__(self, receive_func, channel_filter):
         self.receive_func = receive_func
+        self.channel_filter = channel_filter
 
     def start(self):
         try:

--- a/bsread/tables/bases.py
+++ b/bsread/tables/bases.py
@@ -26,9 +26,10 @@ class BaseDataTable(ABC):
 
 class BaseTable(ABC):
 
-    def __init__(self, receive_func, channel_filter):
+    def __init__(self, receive_func, channel_filter, clear):
         self.receive_func = receive_func
         self.channel_filter = channel_filter
+        self.clear = clear
 
     def start(self):
         try:
@@ -42,6 +43,9 @@ class BaseTable(ABC):
     @abstractmethod
     def run(self):
         raise NotImplementedError
+
+    def clear_screen(self):
+        print(chr(27) + "[2J")
 
 
 

--- a/bsread/tables/bases.py
+++ b/bsread/tables/bases.py
@@ -5,8 +5,8 @@ from .data import TableData
 
 class BaseDataTable(ABC):
 
-    def __init__(self, receive_func, max_rows, channel_filter):
-        self.data = TableData(receive_func, max_rows, channel_filter)
+    def __init__(self, receive_func, channel_filter, max_rows):
+        self.data = TableData(receive_func, channel_filter, max_rows)
 
     def start(self):
         try:

--- a/bsread/tables/classic.py
+++ b/bsread/tables/classic.py
@@ -19,7 +19,7 @@ class ClassicTable(BaseTable):
                 print(join(cols))
 
             row = data.values()
-            print(join(map(str, row)))
+            print(join(row))
 
 
 

--- a/bsread/tables/classic.py
+++ b/bsread/tables/classic.py
@@ -1,0 +1,24 @@
+from .bases import BaseTable
+from .data import make_cols, make_row
+
+
+SEPARATOR = "\t"
+
+
+class ClassicTable(BaseTable):
+
+    def run(self):
+        join = SEPARATOR.join
+        while True:
+            msg = self.receive_func()
+
+            if msg.format_changed:
+                print()
+                cols = make_cols(msg)
+                print(join(cols))
+
+            row = make_row(msg)
+            print(join(map(str, row)))
+
+
+

--- a/bsread/tables/classic.py
+++ b/bsread/tables/classic.py
@@ -13,7 +13,9 @@ class ClassicTable(BaseTable):
             msg = self.receive_func()
             data = unpack(msg, self.channel_filter)
 
-            if msg.format_changed:
+            if msg.format_changed or self.clear:
+                if self.clear:
+                    self.clear_screen()
                 print()
                 cols = data.keys()
                 print(join(cols))

--- a/bsread/tables/classic.py
+++ b/bsread/tables/classic.py
@@ -1,5 +1,5 @@
 from .bases import BaseTable
-from .data import make_cols, make_row
+from .data import unpack
 
 
 SEPARATOR = "\t"
@@ -11,13 +11,14 @@ class ClassicTable(BaseTable):
         join = SEPARATOR.join
         while True:
             msg = self.receive_func()
+            data = unpack(msg, self.channel_filter)
 
             if msg.format_changed:
                 print()
-                cols = make_cols(msg)
+                cols = data.keys()
                 print(join(cols))
 
-            row = make_row(msg)
+            row = data.values()
             print(join(map(str, row)))
 
 

--- a/bsread/tables/data.py
+++ b/bsread/tables/data.py
@@ -70,10 +70,10 @@ def unpack(msg, channel_filter):
     return merge_dicts(meta, data)
 
 def unpack_meta(msg):
-    return {i: getattr(msg, i) for i in META}
+    return {i: str(getattr(msg, i)) for i in META}
 
 def unpack_data(msg, channel_filter):
-    return {k: v.value for k, v in msg.data.items() if channel_filter is None or k in channel_filter}
+    return {k: str(v.value) for k, v in msg.data.items() if channel_filter is None or k in channel_filter}
 
 def merge_dicts(*args):
     res = {}

--- a/bsread/tables/data.py
+++ b/bsread/tables/data.py
@@ -12,7 +12,7 @@ META = [
 
 class TableData:
 
-    def __init__(self, receive_func, max_rows, channel_filter):
+    def __init__(self, receive_func, channel_filter, max_rows):
         self.receive_func = receive_func
         self.channel_filter = channel_filter
         self._cols = []

--- a/bsread/tables/data.py
+++ b/bsread/tables/data.py
@@ -1,0 +1,72 @@
+from time import sleep
+from collections import deque
+from threading import Event, Lock, Thread
+
+
+FIXED = [
+    "pulse_id",
+    "global_timestamp",
+    "global_timestamp_offset"
+]
+
+
+class TableData:
+
+    def __init__(self, receive_func, max_rows):
+        self.receive_func = receive_func
+        self._cols = []
+        self._rows = deque(maxlen=max_rows)
+        self.lock_cols = Lock()
+        self.lock_rows = Lock()
+        self.running = Event()
+
+
+    def start(self):
+        def collect():
+            self.running.set()
+            while self.running.is_set():
+                msg = self.receive_func()
+
+                if msg.format_changed:
+                    with self.lock_cols:
+                        self._cols.clear()
+                    with self.lock_rows:
+                        self._rows.clear()
+
+                with self.lock_cols:
+                    if not self._cols:
+                        cols = make_cols(msg)
+                        self._cols.extend(cols)
+
+                row = make_row(msg)
+                with self.lock_rows:
+                    self._rows.append(row)
+
+        Thread(target=collect, daemon=True).start()
+
+
+    def stop(self):
+        self.running.clear()
+        sleep(0.1) # give the collect loop time to end
+
+
+    @property
+    def cols(self):
+        with self.lock_cols:
+            return list(self._cols)
+
+    @property
+    def rows(self):
+        with self.lock_rows:
+            return list(self._rows)
+
+
+
+def make_cols(msg):
+    return FIXED + list(msg.data.keys())
+
+def make_row(msg):
+    return [getattr(msg, i) for i in FIXED] + [v.value for v in msg.data.values()]
+
+
+

--- a/bsread/tables/plain.py
+++ b/bsread/tables/plain.py
@@ -1,5 +1,5 @@
 from .bases import BaseTable
-from .data import make_cols, make_row
+from .data import unpack
 
 
 SEPARATOR = " "
@@ -14,12 +14,15 @@ class PlainTable(BaseTable):
 
         while True:
             msg = self.receive_func()
+            data = unpack(msg, self.channel_filter)
 
             if msg.format_changed or not cols:
-                cols = strs(make_cols(msg))
+                cols = data.keys()
+                cols = strs(cols)
                 widths_cols = lens(cols)
 
-            row = strs(make_row(msg))
+            row = data.values()
+            row = strs(row)
             widths_row = lens(row)
 
             widths_new = maxof(widths_cols, widths_row)

--- a/bsread/tables/plain.py
+++ b/bsread/tables/plain.py
@@ -18,11 +18,9 @@ class PlainTable(BaseTable):
 
             if msg.format_changed or not cols:
                 cols = data.keys()
-                cols = strs(cols)
                 widths_cols = lens(cols)
 
             row = data.values()
-            row = strs(row)
             widths_row = lens(row)
 
             widths_new = maxof(widths_cols, widths_row)
@@ -36,9 +34,6 @@ class PlainTable(BaseTable):
             print(join(pad(row, widths)))
 
 
-
-def strs(seq):
-    return [str(i) for i in seq]
 
 def lens(seq):
     return [len(i) for i in seq]

--- a/bsread/tables/plain.py
+++ b/bsread/tables/plain.py
@@ -16,7 +16,7 @@ class PlainTable(BaseTable):
             msg = self.receive_func()
             data = unpack(msg, self.channel_filter)
 
-            if msg.format_changed or not cols:
+            if msg.format_changed or self.clear or not cols:
                 cols = data.keys()
                 widths_cols = lens(cols)
 
@@ -26,7 +26,9 @@ class PlainTable(BaseTable):
             widths_new = maxof(widths_cols, widths_row)
             widths_changed = widths_new != widths
 
-            if msg.format_changed or widths_changed:
+            if msg.format_changed or self.clear or widths_changed:
+                if self.clear:
+                    self.clear_screen()
                 widths = widths_new
                 print()
                 print(join(pad(cols, widths)))

--- a/bsread/tables/plain.py
+++ b/bsread/tables/plain.py
@@ -1,0 +1,50 @@
+from .bases import BaseTable
+from .data import make_cols, make_row
+
+
+SEPARATOR = " "
+
+
+class PlainTable(BaseTable):
+
+    def run(self):
+        join = SEPARATOR.join
+        cols = []
+        widths = []
+
+        while True:
+            msg = self.receive_func()
+
+            if msg.format_changed or not cols:
+                cols = strs(make_cols(msg))
+                widths_cols = lens(cols)
+
+            row = strs(make_row(msg))
+            widths_row = lens(row)
+
+            widths_new = maxof(widths_cols, widths_row)
+            widths_changed = widths_new != widths
+
+            if msg.format_changed or widths_changed:
+                widths = widths_new
+                print()
+                print(join(pad(cols, widths)))
+
+            print(join(pad(row, widths)))
+
+
+
+def strs(seq):
+    return [str(i) for i in seq]
+
+def lens(seq):
+    return [len(i) for i in seq]
+
+def pad(strings, lengths):
+    return [s.ljust(l) for s, l in zip(strings, lengths)]
+
+def maxof(seq1, seq2):
+    return [max(i, j) for i, j in zip(seq1, seq2)]
+
+
+

--- a/bsread/tables/rich.py
+++ b/bsread/tables/rich.py
@@ -9,10 +9,10 @@ from .bases import BaseDataTable
 
 class RichTable(BaseDataTable):
 
-    def __init__(self, receive_func):
+    def __init__(self, receive_func, channel_filter):
         self.console = Console()
         max_rows = max(1, self.console.size.height - 4)
-        super().__init__(receive_func, max_rows)
+        super().__init__(receive_func, max_rows, channel_filter)
 
     def run(self):
         with Live(console=self.console, auto_refresh=False) as live:

--- a/bsread/tables/rich.py
+++ b/bsread/tables/rich.py
@@ -12,7 +12,7 @@ class RichTable(BaseDataTable):
     def __init__(self, receive_func, channel_filter):
         self.console = Console()
         max_rows = max(1, self.console.size.height - 4)
-        super().__init__(receive_func, max_rows, channel_filter)
+        super().__init__(receive_func, channel_filter, max_rows)
 
     def run(self):
         with Live(console=self.console, auto_refresh=False) as live:

--- a/bsread/tables/rich.py
+++ b/bsread/tables/rich.py
@@ -9,9 +9,9 @@ from .bases import BaseDataTable
 
 class RichTable(BaseDataTable):
 
-    def __init__(self, receive_func, channel_filter):
+    def __init__(self, receive_func, channel_filter, _clear):
         self.console = Console()
-        max_rows = max(1, self.console.size.height - 4)
+        max_rows = max(1, self.console.size.height - 4) #if clear else None
         super().__init__(receive_func, channel_filter, max_rows)
 
     def run(self):

--- a/bsread/tables/rich.py
+++ b/bsread/tables/rich.py
@@ -1,0 +1,32 @@
+from time import sleep
+
+from rich.console import Console
+from rich.table import Table
+from rich.live import Live
+
+from .bases import BaseDataTable
+
+
+class RichTable(BaseDataTable):
+
+    def __init__(self, receive_func):
+        self.console = Console()
+        max_rows = max(1, self.console.size.height - 4)
+        super().__init__(receive_func, max_rows)
+
+    def run(self):
+        with Live(console=self.console, auto_refresh=False) as live:
+            while True:
+                live.update(self.make_table(), refresh=True)
+                sleep(0.1)
+
+    def make_table(self):
+        tab = Table(show_lines=False)
+        for col in self.data.cols:
+            tab.add_column(str(col))
+        for row in self.data.rows:
+            tab.add_row(*map(str, row))
+        return tab
+
+
+

--- a/bsread/tables/rich.py
+++ b/bsread/tables/rich.py
@@ -23,9 +23,9 @@ class RichTable(BaseDataTable):
     def make_table(self):
         tab = Table(show_lines=False)
         for col in self.data.cols:
-            tab.add_column(str(col))
+            tab.add_column(col)
         for row in self.data.rows:
-            tab.add_row(*map(str, row))
+            tab.add_row(*row)
         return tab
 
 

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -7,10 +7,10 @@ from .bases import BaseDataTable
 
 class TextualTable(BaseDataTable):
 
-    def __init__(self, receive_func):
+    def __init__(self, receive_func, channel_filter):
         self.console = Console()
         max_rows = max(1, self.console.size.height - 1)
-        super().__init__(receive_func, max_rows)
+        super().__init__(receive_func, max_rows, channel_filter)
         self.app = TableApp(self.data)
 
     def run(self):

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -7,9 +7,9 @@ from .bases import BaseDataTable
 
 class TextualTable(BaseDataTable):
 
-    def __init__(self, receive_func, channel_filter):
+    def __init__(self, receive_func, channel_filter, _clear):
         self.console = Console()
-        max_rows = max(1, self.console.size.height - 1)
+        max_rows = max(1, self.console.size.height - 1) #if clear else None
         super().__init__(receive_func, channel_filter, max_rows)
         self.app = TableApp(self.data)
 

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -10,7 +10,7 @@ class TextualTable(BaseDataTable):
     def __init__(self, receive_func, channel_filter):
         self.console = Console()
         max_rows = max(1, self.console.size.height - 1)
-        super().__init__(receive_func, max_rows, channel_filter)
+        super().__init__(receive_func, channel_filter, max_rows)
         self.app = TableApp(self.data)
 
     def run(self):

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -36,10 +36,39 @@ class TableApp(App):
     def make_table(self):
         data = self.data
         table = self.table
-        table.clear(columns=True)
-        table.add_columns(*data.cols)
-        for row in data.rows:
+
+        if not table.columns:
+            table.add_columns(*data.cols)
+
+        data_rows = data.rows
+
+        n_data_rows = len(data_rows)
+        n_table_rows = len(table.rows)
+
+        # update the existing rows
+        for i, row in enumerate(data_rows[:n_table_rows]):
+            update_row_at(table, i, row)
+
+        # add missing rows
+        for row in data_rows[n_table_rows:]:
             table.add_row(*row)
+
+        # remove extra rows
+        for row_index in reversed(range(n_data_rows, n_table_rows)):
+            remove_row_at(table, row_index)
+
+
+
+def update_row_at(table, row_index, values, update_width=False):
+    for col_index, val in enumerate(values):
+        coord = (row_index, col_index)
+        table.update_cell_at(coord, val, update_width=update_width)
+
+def remove_row_at(table, row_index):
+    col_index = 0
+    coord = (row_index, col_index)
+    row_key, _col_key = table.coordinate_to_cell_key(coord)
+    table.remove_row(row_key)
 
 
 

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -37,10 +37,15 @@ class TableApp(App):
         data = self.data
         table = self.table
 
-        if not table.columns:
-            table.add_columns(*data.cols)
-
         data_rows = data.rows
+        data_cols = data.cols
+
+        table_cols = get_cols(table)
+
+        # only rebuild columns if they changed
+        if table_cols != data_cols:
+            table.clear(columns=True)
+            table.add_columns(*data_cols)
 
         n_data_rows = len(data_rows)
         n_table_rows = len(table.rows)
@@ -58,6 +63,11 @@ class TableApp(App):
             remove_row_at(table, row_index)
 
 
+
+def get_cols(table):
+    # ck => textual.widgets._data_table.ColumnKey
+    # ck.label => rich.text.Text
+    return [ck.label.plain for ck in table.columns.values()]
 
 def update_row_at(table, row_index, values, update_width=False):
     for col_index, val in enumerate(values):

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -1,0 +1,45 @@
+from rich.console import Console
+from textual.app import App
+from textual.widgets import DataTable as TableWidget
+
+from .bases import BaseDataTable
+
+
+class TextualTable(BaseDataTable):
+
+    def __init__(self, receive_func):
+        self.console = Console()
+        max_rows = max(1, self.console.size.height - 1)
+        super().__init__(receive_func, max_rows)
+        self.app = TableApp(self.data)
+
+    def run(self):
+        self.app.run()
+
+
+class TableApp(App):
+
+    BINDINGS = [("ctrl+c", "quit")]
+    CSS = "DataTable { height: 100%; width: 100%; }"
+
+    def __init__(self, data):
+        super().__init__()
+        self.data = data
+        self.table = TableWidget()
+
+    def compose(self):
+        yield self.table
+
+    def on_mount(self):
+        self.set_interval(0.1, self.make_table)
+
+    def make_table(self):
+        data = self.data
+        table = self.table
+        table.clear(columns=True)
+        table.add_columns(*data.cols)
+        for row in data.rows:
+            table.add_row(*row)
+
+
+

--- a/bsread/tables/textual.py
+++ b/bsread/tables/textual.py
@@ -17,6 +17,7 @@ class TextualTable(BaseDataTable):
         self.app.run()
 
 
+
 class TableApp(App):
 
     BINDINGS = [("ctrl+c", "quit")]
@@ -32,6 +33,7 @@ class TableApp(App):
 
     def on_mount(self):
         self.set_interval(0.1, self.make_table)
+
 
     def make_table(self):
         data = self.data


### PR DESCRIPTION
- refactors the table printing of `bs receive` into a separate logic

- implements 4 types of table (can be selected from CLI)
  - classic : the tab-separated style used so far (problems with misalignment and "too many columns")
  - plain : nicer variant that aligns columns properly (still problems with "too many columns")
  - rich : uses [rich](https://github.com/Textualize/rich/) to make a fancy table (can handle "too many columns" to some extent, by shrinking columns evenly)
  - textual : uses [textual](https://github.com/Textualize/textual) to make a very fancy table (handles "too many columns" via scrolling off screen)